### PR TITLE
fix(server): source MCP serverInfo from package.json

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import express from 'express';
 import { config } from 'dotenv';
+import pkg from '../package.json' with { type: 'json' };
 import pino from 'pino';
 import pinoHttp from 'pino-http';
 import {
@@ -220,8 +221,8 @@ async function readWidgetHtml(widgetId: string): Promise<string> {
  */
 function createMcpServer(protocolEra: ProtocolEra): McpServer {
   const server = new McpServer({
-    name: 'mcp-app-template',
-    version: '1.0.0',
+    name: pkg.name,
+    version: pkg.version,
   });
 
   // ext-apps 1.x is typed against the v1 SDK; bridge the v2 McpServer once


### PR DESCRIPTION
## Summary

The `McpServer` name/version in `server/src/server.ts` were hardcoded and already out of sync with `server/package.json` (`mcp-app-template` vs `mcp-app-server`). Since this is a template, downstream renames and `npm version` bumps would never reach the identity MCP hosts see.

This sources `serverInfo` from the manifest via a static JSON import:

```ts
import pkg from '../package.json' with { type: 'json' };
```

Closes #108

## Testing

- `npx tsc --noEmit` and a full `tsc` emit verified the import compiles and the output layout is unchanged
- `npm run test:server` — 9 tests pass
- Verified at runtime: `node --input-type=module -e "import pkg from '.../server/package.json' with { type: 'json' }"` loads name/version correctly

## Notes for reviewers

The reported server name changes from `mcp-app-template` to `mcp-app-server` (the package name). If a different display name is preferred, that belongs in `server/package.json` or the implementation `title` field.

## AI Disclosure

This change was written with Claude Code. The first pass used a runtime `fs.readFileSync` + type cast because Claude assumed a static JSON import would violate `rootDir` (TS6059). I mentioned the typed imports work in Node.js 24 (maybe 22 too?). I pushed back and asked why we couldn't just import `package.json` — Claude then tested it against a real `tsc` build, confirmed the assumption was wrong, and simplified to the static import. I reviewed everything before it landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
