### PR TITLE
chore(dev): per-client widget HTML serving and no-manual-build dev flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,14 +14,23 @@ LOG_LEVEL=info
 CORS_ORIGIN=*
 # In production, set to your specific domain
 
-# Base URL for widget assets - required in production, optional in development (widgets are fetched from this URL instead of local filesystem)
-# For Pomerium tunnel: BASE_URL=https://template.first-wallaby-240.pom.run
-# For CDN/production: BASE_URL=https://echo-ui.maisonlab.dev
+# Public base URL for widget assets - required in production, optional in development
+# Dev: point it at a tunnel to the widget dev server (port 4444) so hosts that
+# load external assets get live modules + HMR through the tunnel, e.g. a second
+# `ssh -R 0 pom.run` session: BASE_URL=https://widgets.first-wallaby-240.pom.run
+# Production: your CDN/static host, e.g. BASE_URL=https://echo-ui.maisonlab.dev
 # BASE_URL=
+
+# Clients that always get fully inlined widget HTML in dev (comma-separated,
+# case-insensitive substring match against the MCP client's name/title).
+# claude.ai can't load a Vite dev module graph from an external origin.
+# Unidentified clients are inlined too. Default: claude
+# WIDGET_INLINE_CLIENTS=claude
 
 # Build Configuration
 # BUILD_CONCURRENCY=4
 # Number of parallel widget builds (default: CPU count / 2)
 
-# Local dev only: inline JS/CSS + images, fonts via Google Fonts (npm run dev:inline)
+# Force inlined widget HTML for every client (npm run dev:inline sets this).
+# Normally unnecessary: `npm run dev` already inlines per-client via WIDGET_INLINE_CLIENTS.
 # INLINE_DEV_MODE=true

--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,10 @@ CORS_ORIGIN=*
 # Force inlined widget HTML for every client (npm run dev:inline sets this).
 # Normally unnecessary: `npm run dev` already inlines per-client via WIDGET_INLINE_CLIENTS.
 # INLINE_DEV_MODE=true
+
+# Experimental: clients that get dev-server modules via a dynamic import()
+# bootstrap instead of inlined HTML (same matching rules as WIDGET_INLINE_CLIENTS,
+# takes precedence over it). srcdoc-iframe hosts (e.g. claude.ai) don't execute
+# static <script src> tags but may allow dynamic loading from resourceDomains
+# origins. Requires BASE_URL set to an https tunnel of the widget dev server.
+# WIDGET_BOOTSTRAP_CLIENTS=claude

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,6 +273,8 @@ The widget origin comes from `BASE_URL` when set (a tunnel to port 4444, e.g. a 
 
 `INLINE_DEV_MODE=true` (`npm run dev:inline`) forces inlined HTML for every client. Inlining is never used in production — hosts fetch widget assets from `BASE_URL`.
 
+Experimental: `WIDGET_BOOTSTRAP_CLIENTS` (dev only, takes precedence over the inline list) serves matching clients a tiny HTML that loads the dev module graph via dynamic `import()` instead of a static `<script src>` tag — srcdoc-iframe hosts like claude.ai don't execute static external script tags but may allow dynamic loading from `resourceDomains` origins (this is how the official ext-apps map-server example loads CesiumJS). Requires `BASE_URL` set to an https tunnel. If it proves out against claude.ai, it enables no-build dev there too.
+
 If you self-host tunneling, you can create a public route in Pomerium for widgets or host them elsewhere (Vercel, Netlify, etc.) — just add those domains to `resourceDomains`.
 
 ### External Resources & CSP

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,6 +271,8 @@ In development the widget resource callback (`server/src/server.ts`) picks the H
 
 The widget origin comes from `BASE_URL` when set (a tunnel to port 4444, e.g. a second `ssh -R 0:localhost:4444 pom.run` session — the Vite dev server derives `allowedHosts` and HMR websocket config from it too), otherwise `http://localhost:4444`.
 
+These are two independent pipelines from the same source files. Edit loop: HMR clients get websocket module pushes (the watch build's output is never used by them, and the dev server ignores `assets/` writes so rebuilds can't trigger reloads); an inline client's rendered widget is a frozen snapshot — the next `resources/read` serves freshly re-inlined HTML, so re-invoke the tool in claude.ai to see changes (a page refresh may hit a host cache).
+
 `INLINE_DEV_MODE=true` (`npm run dev:inline`) forces inlined HTML for every client. Inlining is never used in production — hosts fetch widget assets from `BASE_URL`.
 
 Experimental: `WIDGET_BOOTSTRAP_CLIENTS` (dev only, takes precedence over the inline list) serves matching clients a tiny HTML that loads the dev module graph via dynamic `import()` instead of a static `<script src>` tag — srcdoc-iframe hosts like claude.ai don't execute static external script tags but may allow dynamic loading from `resourceDomains` origins (this is how the official ext-apps map-server example loads CesiumJS). Requires `BASE_URL` set to an https tunnel. If it proves out against claude.ai, it enables no-build dev there too.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,12 +30,15 @@ This starts both the MCP server (`http://localhost:8080`) and widget dev server 
 **Development:**
 
 ```bash
-npm run dev           # Start everything (server + widgets in watch mode)
-npm run dev:inline    # Inlined assets for Claude.ai or remote sharing via ssh -R 0 pom.run
-npm run dev:server    # Start only MCP server (watch mode)
-npm run dev:widgets   # Start only widget dev server
-npm run inspect       # Test with MCP Inspector
+npm run dev               # Start everything (server + widget dev server + background watch build)
+npm run dev:inline        # Force inlined assets for every client (rarely needed)
+npm run dev:server        # Start only MCP server (watch mode)
+npm run dev:widgets       # Start only widget dev server
+npm run dev:widgets:build # Start only the widget watch build
+npm run inspect           # Test with MCP Inspector
 ```
+
+`npm run dev` needs no manual build step: a background `vite build --watch` keeps `assets/` fresh, and the server decides per MCP request whether to serve live dev-server modules (HMR) or fully inlined HTML, based on the requesting client (see "Per-Client Widget HTML" below).
 
 **Building:**
 
@@ -259,11 +262,18 @@ Hosts provide `containerDimensions` (`maxHeight`, `maxWidth`, `height`, `width`)
 
 UI tools always include their MCP Apps metadata and a text fallback; hosts that do not render MCP Apps can ignore the UI metadata.
 
-### Inline Asset Mode (Local Development Only)
+### Per-Client Widget HTML (Development)
 
-`npm run dev:inline` (`INLINE_DEV_MODE=true`) inlines JS/CSS into widget HTML as `<script>`/`<style>` blocks, inlines local images as data URIs via Vite's `assetsInlineLimit`, and loads fonts via Google Fonts (domains auto-added to `resourceDomains`). Use this for testing in Claude.ai or when sharing your work remotely via `ssh -R 0 pom.run`.
+In development the widget resource callback (`server/src/server.ts`) picks the HTML per MCP request using helpers in `server/src/widget-html.ts`:
 
-If you self-host tunneling, you can create a public route in Pomerium for widgets or host them elsewhere (Vercel, Netlify, etc.) — just add those domains to `resourceDomains`. Inline mode is not needed in production.
+- Clients matching `WIDGET_INLINE_CLIENTS` (default `claude`, comma-separated case-insensitive substring match on the client's `_meta` `clientInfo` name/title) — and clients that send no identity — get **fully inlined HTML** built from `assets/` (JS/CSS as `<script>`/`<style>` blocks, local images as data URIs, fonts via Google Fonts with domains auto-added to `resourceDomains`). The background watch build plus an `fs.watch` on `assets/` keeps this fresh on every file change.
+- All other identified clients (e.g. ChatGPT dev mode) get **dev-server HTML** referencing live Vite modules, with the widget origin and its `ws(s)://` HMR websocket added to the resource CSP.
+
+The widget origin comes from `BASE_URL` when set (a tunnel to port 4444, e.g. a second `ssh -R 0:localhost:4444 pom.run` session — the Vite dev server derives `allowedHosts` and HMR websocket config from it too), otherwise `http://localhost:4444`.
+
+`INLINE_DEV_MODE=true` (`npm run dev:inline`) forces inlined HTML for every client. Inlining is never used in production — hosts fetch widget assets from `BASE_URL`.
+
+If you self-host tunneling, you can create a public route in Pomerium for widgets or host them elsewhere (Vercel, Netlify, etc.) — just add those domains to `resourceDomains`.
 
 ### External Resources & CSP
 
@@ -399,8 +409,9 @@ PORT=8080                      # Server port
 WIDGET_PORT=4444               # Widget dev server port (default: 4444)
 LOG_LEVEL=info                 # Pino log level: fatal, error, warn, info, debug, trace
 CORS_ORIGIN=*                  # CORS origin (set to domain in production)
-BASE_URL=                      # Optional CDN URL for widget assets
-INLINE_DEV_MODE=true      # Local dev only: inline JS/CSS + images, fonts via Google Fonts (npm run dev:inline)
+BASE_URL=                      # Public widget asset URL: CDN in production, tunnel to the widget dev server in dev
+WIDGET_INLINE_CLIENTS=claude   # Clients served inlined HTML in dev (comma-separated substring match)
+INLINE_DEV_MODE=true           # Force inlined widget HTML for every client (npm run dev:inline)
 ```
 
 Requirements:
@@ -514,7 +525,7 @@ docker-compose -f docker/docker-compose.yml up -d
 - Widget components accept an `app` prop typed as `AppLike<T>` so the real `App` or `createMockApp()` can be injected
 - Use `containerDimensions.maxHeight` (not viewport height) for responsive widget sizing
 - When adding new App API calls (`openLink`, `sendMessage`, `updateModelContext`), add the method signature to `AppLike` in `widgets/src/types/mcp-app.ts` and the mock in `widgets/src/mocks/mock-app.ts`
-- Use `npm run dev:inline` for Claude.ai testing or remote sharing via `ssh -R 0 pom.run`
+- `npm run dev` covers Claude.ai automatically (per-client inlined HTML); set `BASE_URL` to a tunnel of port 4444 for HMR through hosts that load external assets
 - Widget build is separate from server build - always run `npm run build:widgets` when modifying widgets
 - The `text/html;profile=mcp-app` MIME type is non-negotiable for MCP Apps UI loading
 - MCP HTTP handling is stateless - each request gets a fresh MCP server instance and no session affinity is required

--- a/README.md
+++ b/README.md
@@ -64,10 +64,13 @@ npm install
 npm run dev
 ```
 
-This starts both the MCP server and widget dev server:
+This starts everything you need — no manual build step:
 
 - **MCP Server**: `http://localhost:8080`
-- **Widget Assets**: `http://localhost:4444`
+- **Widget dev server** (live modules + HMR): `http://localhost:4444`
+- **Background watch build**: keeps `assets/` fresh so hosts that need self-contained HTML (like Claude.ai) always get an up-to-date inlined widget
+
+The server picks the right widget HTML per request: hosts that can load external assets get live dev modules with hot module replacement, and hosts that can't (Claude.ai, plus any client that doesn't identify itself) automatically get fully inlined HTML rebuilt on every file change. See [Inline Widget Assets](#inline-widget-assets).
 
 > **Note:** The MCP server is a backend service. To test it, follow the host connection steps below (ChatGPT example) or use `npm run inspect` for local testing.
 
@@ -77,42 +80,24 @@ You should see output indicating both servers are running successfully:
 ❯ npm run dev
 
 > mcp-app-typescript-template@1.0.0 dev
-> concurrently "npm run dev:server" "npm run dev:widgets"
+> concurrently -n server,widgets,build "npm run dev:server" "npm run dev:widgets" "npm run dev:widgets:build"
 
-[1]
-[1] > mcp-app-typescript-template@1.0.0 dev:widgets
-[1] > npm run dev --workspace=widgets
-[1]
-[0]
-[0] > mcp-app-typescript-template@1.0.0 dev:server
-[0] > npm run dev --workspace=server
-[0]
-[1]
-[1] > mcp-app-widgets@1.0.0 dev
-[1] > vite
-[1]
-[0]
-[0] > mcp-app-server@1.0.0 dev
-[0] > tsx watch src/server.ts
-[0]
-[1]
-[1] Found 1 widget(s):
-[1]   - echo
-[1]
-[1]
-[1]   VITE v6.4.1  ready in 151 ms
-[1]
-[1]   ➜  Local:   http://localhost:4444/
-[1]   ➜  Network: use --host to expose
-[0] [12:45:12] INFO: Starting MCP App Template server
-[0]     port: 8080
-[0]     nodeEnv: "development"
-[0]     logLevel: "info"
-[0]     assetsDir: "/Users/nicktaylor/dev/oss/mcp-app-typescript-template/assets"
-[0] [12:45:12] INFO: Server started successfully
-[0]     port: 8080
-[0]     mcpEndpoint: "http://localhost:8080/mcp"
-[0]     healthEndpoint: "http://localhost:8080/health"
+[widgets] > vite
+[server] > tsx watch src/server.ts
+[build] > vite build --watch
+
+[widgets] Found 1 widget(s):
+[widgets]   - echo
+[widgets]
+[widgets]   VITE v8.2.1  ready in 310 ms
+[widgets]   ➜  Local:   http://localhost:4444/
+[build] ✓ 1936 modules transformed.
+[server] [12:45:12] INFO: Starting MCP App Template server
+[server]     port: 8080
+[server]     nodeEnv: "development"
+[server] [12:45:12] INFO: Server started successfully
+[server]     mcpEndpoint: "http://localhost:8080/mcp"
+[server]     healthEndpoint: "http://localhost:8080/health"
 ```
 
 ### Connect to a Host (ChatGPT example)
@@ -166,7 +151,26 @@ Look for the **Port Forward Status** section showing:
 
 The tunnel stays active as long as the SSH session is running.
 
+**Claude.ai:** the same tunnel works out of the box — add the connector URL in Claude.ai settings. Claude.ai can't load widget assets from an external dev server, so the template automatically serves it fully inlined widget HTML, rebuilt on every file change (no HMR, but no manual build step either).
+
 **Other hosts:** Claude Desktop, VS Code, Goose, and other MCP Apps hosts follow the same pattern—add a connector to your `/mcp` endpoint and refresh after changes.
+
+### Optional: Tunnel the Widget Dev Server (HMR through the tunnel)
+
+Hosts that honor the resource CSP (e.g. ChatGPT in dev mode) can load live widget modules — with hot module replacement — through a second tunnel pointed at the widget dev server:
+
+```bash
+# Second terminal: tunnel the widget dev server (port 4444)
+ssh -R 0:localhost:4444 pom.run
+```
+
+Then set `BASE_URL` in `.env` to that tunnel's public URL and restart `npm run dev`:
+
+```bash
+BASE_URL=https://widgets.first-wallaby-240.pom.run
+```
+
+Widget HTML, CSP domains (`https://` + `wss://` for HMR), and Vite's allowed hosts are all derived from `BASE_URL` automatically. Without `BASE_URL`, widget assets are served from `http://localhost:4444`, which only works when the host's iframe runs in a browser on your machine.
 
 ### Success! What's Next?
 
@@ -182,10 +186,11 @@ Now that your app is working, you can:
 ### Development
 
 ```bash
-# Start everything (server + widgets in watch mode)
+# Start everything (server + widget dev server + background watch build)
+# Serves HMR modules to hosts that support them, auto-inlined HTML to the rest
 npm run dev
 
-# Inlined assets mode for testing in Claude.ai or sharing remotely via ssh -R 0 pom.run
+# Force inlined assets for every client (rarely needed — npm run dev handles this per client)
 npm run dev:inline
 
 # Start only MCP server (watch mode)
@@ -575,23 +580,19 @@ This happens automatically via `getUiCapability()` from `@modelcontextprotocol/e
 
 ### Inline Widget Assets
 
-Some hosts (e.g. Claude.ai) require fully self-contained HTML — external `<script>` and `<link>` tags won't load inside their sandboxed iframes. Inline mode is also useful when sharing your work remotely via `ssh -R 0 pom.run`.
+Some hosts (e.g. Claude.ai) require fully self-contained HTML — external `<script>` and `<link>` tags won't load inside their sandboxed iframes.
 
-```bash
-npm run dev:inline
-```
+In development, `npm run dev` handles this **automatically and per request**: the server inspects each MCP request's client identity (`clientInfo` in `_meta`) and serves inlined HTML to clients matching `WIDGET_INLINE_CLIENTS` (default: `claude`) and to clients that don't identify themselves. Everyone else gets live dev-server modules with HMR. A background `vite build --watch` keeps the inlined HTML fresh on every file change — you never run a build manually.
 
-This produces self-contained HTML by:
+Inlined HTML is self-contained:
 
 - **JS/CSS** — inlined as `<script>`/`<style>` blocks
 - **Local images** — inlined as data URIs via Vite's `assetsInlineLimit`
 - **Fonts** — loaded via Google Fonts (the required domains `fonts.googleapis.com` and `fonts.gstatic.com` are automatically added to `resourceDomains` in the CSP)
 
-The widget build runs in watch mode so file changes are automatically rebuilt.
+To force inlining for every client regardless of identity, run `npm run dev:inline` (sets `INLINE_DEV_MODE=true`). To change which clients are inlined, set `WIDGET_INLINE_CLIENTS` (comma-separated, case-insensitive substring match against the client's name/title). The server logs each widget request's `clientInfo` and the chosen mode, so it's easy to see what a host identifies as.
 
-> **When is inline mode needed?** Only when using `ssh -R 0 pom.run` to tunnel your local server. If you self-host tunneling, you can create a public route in [Pomerium](https://www.pomerium.com/) for widgets or host them elsewhere (Vercel, Netlify, etc.) — just add those domains to `resourceDomains` in the CSP metadata.
->
-> Inline mode is not needed in production — once deployed to a public URL, hosts fetch widget assets directly via normal URLs.
+> Inlining is not used in production — once widget assets are deployed to a public URL (`BASE_URL`), hosts fetch them directly via normal URLs.
 
 ### Loading External Resources (Images, APIs, etc.)
 
@@ -720,10 +721,16 @@ LOG_LEVEL=info          # fatal, error, warn, info, debug, trace
 # CORS (development)
 CORS_ORIGIN=*
 
-# Asset Base URL (for CDN)
+# Public base URL for widget assets
+# Dev: a tunnel to the widget dev server (enables HMR through hosts that load external assets)
+# Production: your CDN/static host (required)
 # BASE_URL=https://cdn.example.com/assets
 
-# Local dev only: inline JS/CSS + images, fonts via Google Fonts (npm run dev:inline)
+# Clients that get fully inlined widget HTML in dev (comma-separated substring
+# match on client name/title; unidentified clients are always inlined)
+# WIDGET_INLINE_CLIENTS=claude
+
+# Force inlined widget HTML for every client (npm run dev:inline sets this)
 # INLINE_DEV_MODE=true
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This starts everything you need — no manual build step:
 - **Widget dev server** (live modules + HMR): `http://localhost:4444`
 - **Background watch build**: keeps `assets/` fresh so hosts that need self-contained HTML (like Claude.ai) always get an up-to-date inlined widget
 
-The server picks the right widget HTML per request: hosts that can load external assets get live dev modules with hot module replacement, and hosts that can't (Claude.ai, plus any client that doesn't identify itself) automatically get fully inlined HTML rebuilt on every file change. See [Inline Widget Assets](#inline-widget-assets).
+The server picks the right widget HTML per request: hosts that can load external assets get live dev modules with hot module replacement, and hosts that can't (Claude.ai, plus any client that doesn't identify itself) automatically get fully inlined HTML rebuilt on every file change. See [How Development Serving Works](#how-development-serving-works).
 
 > **Note:** The MCP server is a backend service. To test it, follow the host connection steps below (ChatGPT example) or use `npm run inspect` for local testing.
 
@@ -577,6 +577,40 @@ The server inspects the client's capabilities on each request, carried in that r
 - **Text-only hosts** (terminal clients, basic MCP consumers) — Tools still advertise UI metadata, which hosts can ignore, and return plain text responses without `structuredContent`
 
 This happens automatically via `getUiCapability()` from `@modelcontextprotocol/ext-apps/server`. No widget changes are needed — the server handles the fallback.
+
+### How Development Serving Works
+
+`npm run dev` runs three processes side by side:
+
+| Process             | What it does                                                                            |
+| ------------------- | --------------------------------------------------------------------------------------- |
+| `dev:server`        | MCP server on `:8080` — decides **per request** which widget HTML to serve              |
+| `dev:widgets`       | Vite dev server on `:4444` — live source modules + HMR websocket                        |
+| `dev:widgets:build` | `vite build --watch` — keeps `assets/` fresh so an inlined snapshot is always available |
+
+These form **two independent delivery pipelines** from the same source files. The watch build is never involved in the HMR path — it exists solely to keep a self-contained snapshot on standby for hosts that need one.
+
+#### First render (a host requests the widget)
+
+When a tool call renders the widget, the host issues `resources/read` and the server inspects the client's identity (`clientInfo` in the request `_meta`):
+
+1. **Matches `WIDGET_INLINE_CLIENTS`** (default: `claude`) **or sends no identity** → the server returns a **self-contained snapshot**: the latest `assets/` build with JS/CSS inlined and local images as data URIs. Nothing is fetched at runtime; the iframe has no connection back to your machine.
+2. **Any other identified client** (e.g. ChatGPT dev mode) → the server returns a **~300-byte shell** whose module script points at the Vite dev server (`BASE_URL` if set, else `http://localhost:4444`). The browser loads your source files as native ES modules, transformed in memory — the `assets/` build is not involved at any point. CSP `resourceDomains`/`connectDomains` (including the `ws(s)://` HMR socket) are set to match.
+
+#### While you develop (save a file)
+
+- **HMR clients** — Vite pushes the changed module over the websocket and React Fast Refresh swaps it in place. Instant, no reload, component state preserved. The watch build also re-runs in the background, but its output isn't used by these clients, and the dev server deliberately ignores `assets/` writes so a finishing build can never trigger a page reload.
+- **Inline clients (Claude.ai)** — the rendered widget is a frozen snapshot; nothing can be pushed to it. The watch build finishes (~1s) and the server re-inlines automatically, so the **next** `resources/read` returns fresh HTML. Invoke the tool again to see your changes — a browser refresh may serve a host-cached copy, so re-invoking is the reliable path.
+
+> **Experimental:** `WIDGET_BOOTSTRAP_CLIENTS` serves matching clients a shell that loads the dev module graph via dynamic `import()` instead of a static script tag — srcdoc-iframe hosts like Claude.ai don't execute static external script tags but may allow dynamic loading from `resourceDomains` origins. If this proves out, Claude.ai can join the HMR pipeline too. Requires `BASE_URL` set to an https tunnel; off by default.
+
+#### Production is unaffected
+
+None of this machinery runs in production (`NODE_ENV=production`):
+
+- `npm run build` output is unchanged: hashed bundles in `assets/` plus HTML referencing them via `BASE_URL`
+- The server never inlines, never serves dev-server HTML, and ignores `WIDGET_INLINE_CLIENTS` / `WIDGET_BOOTSTRAP_CLIENTS` — all per-client switching is gated on `NODE_ENV=development`
+- Hosts fetch widget assets from `BASE_URL` (CDN or static host) exactly as before
 
 ### Inline Widget Assets
 

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "widgets"
   ],
   "scripts": {
-    "dev": "concurrently \"npm run dev:server\" \"npm run dev:widgets\"",
-    "dev:inline": "INLINE_DEV_MODE=true concurrently \"npm run dev:server\" \"npm run dev:widgets:inline\"",
+    "dev": "concurrently -n server,widgets,build \"npm run dev:server\" \"npm run dev:widgets\" \"npm run dev:widgets:build\"",
+    "dev:inline": "INLINE_DEV_MODE=true concurrently -n server,build \"npm run dev:server\" \"npm run dev:widgets:build\"",
     "dev:server": "npm run dev --workspace=server",
     "dev:widgets": "npm run dev --workspace=widgets",
-    "dev:widgets:inline": "npm run build:watch --workspace=widgets",
+    "dev:widgets:build": "npm run build:watch --workspace=widgets",
     "start": "concurrently \"npm run start:server\" \"npm run start:widgets\"",
     "start:server": "npm run start --workspace=server",
     "start:widgets": "npm run serve --workspace=widgets",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -224,12 +224,20 @@ function createMcpServer(protocolEra: ProtocolEra): McpServer {
     version: '1.0.0',
   });
 
+  // ext-apps 1.x is typed against the v1 SDK; bridge the v2 McpServer once
+  // here. Only registerTool/registerResource are called, and those are
+  // call-compatible at runtime. Drop this when ext-apps targets the v2 SDK.
+  const extAppsServer = server as unknown as Parameters<
+    typeof registerAppTool
+  >[0] &
+    Parameters<typeof registerAppResource>[0];
+
   const serverLogger = logger.child({ protocolEra });
 
   const resourceUri = ECHO_WIDGET.uri;
 
   registerAppResource(
-    server as unknown as Parameters<typeof registerAppResource>[0],
+    extAppsServer,
     resourceUri,
     resourceUri,
     { mimeType: RESOURCE_MIME_TYPE },
@@ -336,7 +344,7 @@ function createMcpServer(protocolEra: ProtocolEra): McpServer {
   );
 
   registerAppTool(
-    server as unknown as Parameters<typeof registerAppTool>[0],
+    extAppsServer,
     'echo',
     {
       title: 'Echo',

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -24,6 +24,14 @@ import {
   type WidgetDescriptor,
 } from './types.js';
 import { clientCanRenderUi } from './ui-capability.js';
+import {
+  getClientIdentity,
+  GOOGLE_FONTS_DOMAINS,
+  inlineWidgetAssets,
+  parseClientList,
+  resolveWidgetOrigin,
+  shouldInlineWidgetHtml,
+} from './widget-html.js';
 
 config();
 
@@ -38,6 +46,15 @@ const CORS_ORIGIN = process.env.CORS_ORIGIN || '*';
 const WIDGET_PORT = Number(process.env.WIDGET_PORT || '4444');
 const { BASE_URL = '' } = process.env;
 const INLINE_DEV_MODE = process.env.INLINE_DEV_MODE === 'true';
+const IS_DEV = (process.env.NODE_ENV || 'development') === 'development';
+// Clients that get fully inlined widget HTML in dev (comma-separated,
+// case-insensitive substring match on the client's name/title). claude.ai
+// can't load a Vite dev module graph from an external origin, so it gets the
+// auto-rebuilt inlined bundle instead. Unidentified clients are also inlined.
+const WIDGET_INLINE_CLIENTS = parseClientList(
+  process.env.WIDGET_INLINE_CLIENTS,
+  ['claude']
+);
 
 const logger = pino({
   level: LOG_LEVEL,
@@ -60,31 +77,67 @@ const ECHO_WIDGET: WidgetDescriptor = {
   uri: 'ui://echo',
 };
 
-/** Pre-inlined widget HTML cache — populated at startup when INLINE_DEV_MODE is true */
+/** Inlined widget HTML cache — invalidated by the assets watcher on rebuilds */
 const inlinedHtmlCache = new Map<string, string>();
 
 function buildInlinedHtml(widgetId: string): string | null {
   const htmlPath = path.join(ASSETS_DIR, `${widgetId}.html`);
   if (!fs.existsSync(htmlPath)) {
-    logger.warn({ htmlPath }, 'Cannot pre-inline: HTML file not found');
+    logger.warn({ htmlPath }, 'Cannot inline: HTML file not found');
     return null;
   }
   const html = fs.readFileSync(htmlPath, 'utf-8');
-  const inlined = inlineWidgetAssets(html);
+  const inlined = inlineWidgetAssets(html, ASSETS_DIR, logger);
   logger.info(
     { widgetId, originalLength: html.length, inlinedLength: inlined.length },
-    'Pre-inlined widget HTML'
+    'Inlined widget HTML'
   );
   return inlined;
 }
 
-function preInlineWidgets(widgetIds: string[]) {
-  for (const id of widgetIds) {
-    const html = buildInlinedHtml(id);
-    if (html) {
-      inlinedHtmlCache.set(id, html);
-    }
+function getInlinedHtml(widgetId: string): string {
+  const cached = inlinedHtmlCache.get(widgetId);
+  if (cached) {
+    return cached;
   }
+  const html = buildInlinedHtml(widgetId);
+  if (!html) {
+    throw new Error(
+      `No built assets for widget "${widgetId}" in ${ASSETS_DIR}. ` +
+        'In dev, the watch build from "npm run dev" produces them a few seconds after startup; ' +
+        'otherwise run "npm run build:widgets".'
+    );
+  }
+  inlinedHtmlCache.set(widgetId, html);
+  return html;
+}
+
+/**
+ * Watch built assets so inlined HTML is refreshed whenever the widget watch
+ * build (`vite build --watch`, part of `npm run dev`) emits new files. The
+ * assets directory may not exist yet on first startup — retry until it does.
+ */
+function watchAssetsForInlining(widgetIds: string[]) {
+  if (!fs.existsSync(ASSETS_DIR)) {
+    setTimeout(() => watchAssetsForInlining(widgetIds), 2000).unref();
+    return;
+  }
+
+  fs.watch(ASSETS_DIR, (eventType, filename) => {
+    if (filename?.endsWith('.html')) {
+      const widgetId = filename.replace('.html', '');
+      if (widgetIds.includes(widgetId)) {
+        logger.info({ widgetId, eventType }, 'Asset changed, re-inlining');
+        const html = buildInlinedHtml(widgetId);
+        if (html) {
+          inlinedHtmlCache.set(widgetId, html);
+        } else {
+          inlinedHtmlCache.delete(widgetId);
+        }
+      }
+    }
+  });
+  logger.info('Watching assets directory for rebuild changes');
 }
 
 /**
@@ -150,85 +203,6 @@ async function readWidgetHtml(widgetId: string): Promise<string> {
   return fs.readFileSync(htmlPath, 'utf-8');
 }
 
-function inlineWidgetAssets(html: string): string {
-  logger.debug({ htmlLength: html.length }, 'Inlining widget assets');
-  let nextHtml = html;
-  const scripts = Array.from(
-    html.matchAll(
-      /<script[^>]*type="module"[^>]*src="([^"]+)"[^>]*><\/script>/g
-    )
-  );
-  logger.debug(
-    { scriptMatches: scripts.length },
-    'Found script tags to inline'
-  );
-  for (const match of scripts) {
-    const src = match[1];
-    const filename = path.basename(src.split('?')[0]);
-    const assetPath = path.join(ASSETS_DIR, filename);
-    logger.debug(
-      { src, filename, assetPath, exists: fs.existsSync(assetPath) },
-      'Processing script'
-    );
-    if (!fs.existsSync(assetPath)) {
-      logger.warn(
-        { assetPath },
-        'Inline asset missing, leaving script tag as-is'
-      );
-      continue;
-    }
-    const js = fs.readFileSync(assetPath);
-    const b64 = js.toString('base64');
-    const inlineTag = `<script type="module" src="data:text/javascript;base64,${b64}"></script>`;
-    nextHtml = nextHtml.replace(match[0], () => inlineTag);
-    logger.debug({ newLength: nextHtml.length }, 'JS inlined');
-  }
-
-  const styles = Array.from(
-    html.matchAll(/<link[^>]*rel="stylesheet"[^>]*href="([^"]+)"[^>]*>/g)
-  );
-  for (const match of styles) {
-    const href = match[1];
-    const filename = path.basename(href.split('?')[0]);
-    const assetPath = path.join(ASSETS_DIR, filename);
-    if (!fs.existsSync(assetPath)) {
-      logger.warn(
-        { assetPath },
-        'Inline asset missing, leaving style tag as-is'
-      );
-      continue;
-    }
-
-    const css = fs.readFileSync(assetPath, 'utf-8');
-    const inlineTag = `<style>${css}</style>`;
-    nextHtml = nextHtml.replace(match[0], () => inlineTag);
-    logger.debug({ newLength: nextHtml.length }, 'CSS inlined');
-  }
-
-  nextHtml = nextHtml
-    .replace(/<link[^>]*rel="modulepreload"[^>]*>/g, '')
-    .replace(/<link[^>]*rel="preload"[^>]*as="style"[^>]*>/g, '');
-
-  if (INLINE_DEV_MODE) {
-    // Inject Google Fonts to replace the @fontsource @font-face rules stripped above.
-    // The host proxies these through its asset proxy so they load in the sandboxed iframe.
-    const googleFontsLink =
-      '<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap">';
-    nextHtml = nextHtml.replace('</head>', `${googleFontsLink}\n</head>`);
-    logger.debug('Injected Google Fonts link for inline mode');
-  }
-
-  logger.debug(
-    {
-      finalLength: nextHtml.length,
-      hasLocalhost: nextHtml.includes('localhost'),
-    },
-    'Inlining complete'
-  );
-
-  return nextHtml;
-}
-
 /**
  * Create an MCP server instance with echo tool
  */
@@ -247,37 +221,50 @@ function createMcpServer(protocolEra: ProtocolEra): McpServer {
     resourceUri,
     resourceUri,
     { mimeType: RESOURCE_MIME_TYPE },
-    async () => {
+    async (_uri, extra) => {
       serverLogger.debug({ resourceUri }, 'Resource callback called');
       const widgetId = resourceUri.replace('ui://', '');
+      // ext-apps types this callback against the v1 SDK; the v2 runtime
+      // supplies ServerContext, so bridge the callback type here.
+      const serverContext = extra as unknown as ServerContext;
+      const clientInfo = getClientIdentity(serverContext);
       try {
-        const html = await readWidgetHtml(widgetId);
-        const devWidgetOrigin = `http://localhost:${WIDGET_PORT}`;
-        const devWidgetOriginAlt = `http://127.0.0.1:${WIDGET_PORT}`;
-        const baseUrlOrigin = new URL(BASE_URL || devWidgetOrigin).origin;
+        // Inlined HTML works in every host; the dev-server module graph
+        // (with HMR) only works in hosts that load external origins from the
+        // resource CSP. Unidentified clients get the safe inlined bundle.
+        const useInline =
+          INLINE_DEV_MODE ||
+          (IS_DEV &&
+            shouldInlineWidgetHtml({
+              clientInfo,
+              inlineClients: WIDGET_INLINE_CLIENTS,
+            }));
 
-        const resourceDomains: string[] = INLINE_DEV_MODE
-          ? []
-          : [baseUrlOrigin];
+        const resourceDomains: string[] = [];
         const connectDomains: string[] = [];
+        let finalHtml: string;
 
-        if (NODE_ENV === 'development' && !INLINE_DEV_MODE) {
-          resourceDomains.push(devWidgetOrigin, devWidgetOriginAlt);
-          connectDomains.push(
-            devWidgetOrigin,
-            devWidgetOriginAlt,
-            devWidgetOrigin.replace('http://', 'ws://'),
-            devWidgetOriginAlt.replace('http://', 'ws://')
-          );
-        }
-
-        if (INLINE_DEV_MODE) {
-          // Google Fonts — needed in inline dev mode where @fontsource local fonts
-          // can't load in sandboxed iframes. Remove if you self-host fonts.
-          resourceDomains.push(
-            'https://fonts.googleapis.com',
-            'https://fonts.gstatic.com'
-          );
+        if (useInline) {
+          finalHtml = getInlinedHtml(widgetId);
+          // Inlining swaps local @fontsource fonts for Google Fonts.
+          // Remove if you self-host fonts.
+          resourceDomains.push(...GOOGLE_FONTS_DOMAINS);
+        } else {
+          finalHtml = await readWidgetHtml(widgetId);
+          const widgetOrigin = resolveWidgetOrigin(BASE_URL, WIDGET_PORT);
+          resourceDomains.push(widgetOrigin.origin);
+          if (IS_DEV) {
+            // Vite dev server: allow module fetches plus the HMR websocket
+            connectDomains.push(widgetOrigin.origin, widgetOrigin.wsOrigin);
+            if (widgetOrigin.isLocalhost) {
+              const altOrigin = `http://127.0.0.1:${WIDGET_PORT}`;
+              resourceDomains.push(altOrigin);
+              connectDomains.push(
+                altOrigin,
+                altOrigin.replace('http://', 'ws://')
+              );
+            }
+          }
         }
 
         const cspMeta =
@@ -293,14 +280,9 @@ function createMcpServer(protocolEra: ProtocolEra): McpServer {
             : undefined;
 
         serverLogger.info(
-          { cspMeta },
-          'Constructed CSP meta for widget resource'
+          { resourceUri, widgetId, clientInfo, useInline, cspMeta },
+          'Widget resource loaded'
         );
-        serverLogger.info({ resourceUri, widgetId }, 'Widget resource loaded');
-
-        const finalHtml = INLINE_DEV_MODE
-          ? (inlinedHtmlCache.get(widgetId) ?? inlineWidgetAssets(html))
-          : html;
 
         return {
           contents: [
@@ -436,25 +418,11 @@ async function main() {
 
   const widgetIds = [ECHO_WIDGET.id];
 
-  if (INLINE_DEV_MODE) {
-    preInlineWidgets(widgetIds);
-
-    // Watch for rebuilds from widget watch mode
-    if (fs.existsSync(ASSETS_DIR)) {
-      fs.watch(ASSETS_DIR, (eventType, filename) => {
-        if (filename?.endsWith('.html')) {
-          const widgetId = filename.replace('.html', '');
-          if (widgetIds.includes(widgetId)) {
-            logger.info({ widgetId, eventType }, 'Asset changed, re-inlining');
-            const html = buildInlinedHtml(widgetId);
-            if (html) {
-              inlinedHtmlCache.set(widgetId, html);
-            }
-          }
-        }
-      });
-      logger.info('Watching assets directory for rebuild changes');
-    }
+  // Inlined HTML can be requested per-client in dev (and always when
+  // INLINE_DEV_MODE forces it), so keep the inline cache fresh as the
+  // widget watch build emits new assets.
+  if (IS_DEV || INLINE_DEV_MODE) {
+    watchAssetsForInlining(widgetIds);
   }
 
   const app = express();

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -25,6 +25,8 @@ import {
 } from './types.js';
 import { clientCanRenderUi } from './ui-capability.js';
 import {
+  buildDevBootstrapHtml,
+  clientMatches,
   getClientIdentity,
   GOOGLE_FONTS_DOMAINS,
   inlineWidgetAssets,
@@ -54,6 +56,16 @@ const IS_DEV = (process.env.NODE_ENV || 'development') === 'development';
 const WIDGET_INLINE_CLIENTS = parseClientList(
   process.env.WIDGET_INLINE_CLIENTS,
   ['claude']
+);
+// Experimental: clients that get dev-server modules via a dynamic import()
+// bootstrap instead of inlined HTML. Hosts rendering widgets in srcdoc
+// iframes don't execute static <script src> tags but may allow dynamic
+// loading from resourceDomains origins. Takes precedence over
+// WIDGET_INLINE_CLIENTS so e.g. WIDGET_BOOTSTRAP_CLIENTS=claude can trial
+// no-build dev against claude.ai (requires BASE_URL to be an https tunnel).
+const WIDGET_BOOTSTRAP_CLIENTS = parseClientList(
+  process.env.WIDGET_BOOTSTRAP_CLIENTS,
+  []
 );
 
 const logger = pino({
@@ -232,19 +244,31 @@ function createMcpServer(protocolEra: ProtocolEra): McpServer {
         // Inlined HTML works in every host; the dev-server module graph
         // (with HMR) only works in hosts that load external origins from the
         // resource CSP. Unidentified clients get the safe inlined bundle.
+        // Bootstrap mode (experimental) loads dev modules via dynamic
+        // import() for srcdoc-iframe hosts that block static script tags.
+        const useBootstrap =
+          IS_DEV &&
+          !INLINE_DEV_MODE &&
+          clientMatches(clientInfo, WIDGET_BOOTSTRAP_CLIENTS);
         const useInline =
-          INLINE_DEV_MODE ||
-          (IS_DEV &&
-            shouldInlineWidgetHtml({
-              clientInfo,
-              inlineClients: WIDGET_INLINE_CLIENTS,
-            }));
+          !useBootstrap &&
+          (INLINE_DEV_MODE ||
+            (IS_DEV &&
+              shouldInlineWidgetHtml({
+                clientInfo,
+                inlineClients: WIDGET_INLINE_CLIENTS,
+              })));
 
         const resourceDomains: string[] = [];
         const connectDomains: string[] = [];
         let finalHtml: string;
 
-        if (useInline) {
+        if (useBootstrap) {
+          const widgetOrigin = resolveWidgetOrigin(BASE_URL, WIDGET_PORT);
+          finalHtml = buildDevBootstrapHtml(widgetId, widgetOrigin.origin);
+          resourceDomains.push(widgetOrigin.origin);
+          connectDomains.push(widgetOrigin.origin, widgetOrigin.wsOrigin);
+        } else if (useInline) {
           finalHtml = getInlinedHtml(widgetId);
           // Inlining swaps local @fontsource fonts for Google Fonts.
           // Remove if you self-host fonts.
@@ -280,7 +304,14 @@ function createMcpServer(protocolEra: ProtocolEra): McpServer {
             : undefined;
 
         serverLogger.info(
-          { resourceUri, widgetId, clientInfo, useInline, cspMeta },
+          {
+            resourceUri,
+            widgetId,
+            clientInfo,
+            useInline,
+            useBootstrap,
+            cspMeta,
+          },
           'Widget resource loaded'
         );
 

--- a/server/src/widget-html.ts
+++ b/server/src/widget-html.ts
@@ -1,0 +1,203 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  CLIENT_INFO_META_KEY,
+  type ServerContext,
+} from '@modelcontextprotocol/server';
+
+/** Minimal logger surface so these helpers stay testable without pino */
+export interface WidgetHtmlLogger {
+  debug: (obj: Record<string, unknown> | string, msg?: string) => void;
+  warn: (obj: Record<string, unknown> | string, msg?: string) => void;
+}
+
+const noopLogger: WidgetHtmlLogger = {
+  debug: () => {},
+  warn: () => {},
+};
+
+export interface ClientIdentity {
+  name?: string;
+  title?: string;
+  version?: string;
+}
+
+/**
+ * Extract the client identity from a per-request envelope.
+ *
+ * Modern (2026-07-28) requests carry `clientInfo` in `_meta`; legacy
+ * stateless requests have no persisted identity and return undefined.
+ */
+export function getClientIdentity(
+  ctx: ServerContext | undefined
+): ClientIdentity | undefined {
+  const envelope = ctx?.mcpReq?.envelope as Record<string, unknown> | undefined;
+  const info = envelope?.[CLIENT_INFO_META_KEY];
+  if (!info || typeof info !== 'object') {
+    return undefined;
+  }
+  const { name, title, version } = info as Record<string, unknown>;
+  const identity: ClientIdentity = {
+    name: typeof name === 'string' ? name : undefined,
+    title: typeof title === 'string' ? title : undefined,
+    version: typeof version === 'string' ? version : undefined,
+  };
+  return identity.name || identity.title ? identity : undefined;
+}
+
+/** Parse a comma-separated client list (e.g. WIDGET_INLINE_CLIENTS) */
+export function parseClientList(
+  raw: string | undefined,
+  fallback: string[]
+): string[] {
+  if (raw === undefined) {
+    return fallback;
+  }
+  return raw
+    .split(',')
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+/**
+ * Decide whether a client should receive fully inlined widget HTML instead
+ * of HTML that references the widget dev server.
+ *
+ * Inlined HTML works in every host (no CSP or network reachability
+ * requirements), so it is the safe default for unidentified clients. Clients
+ * whose name/title matches an entry in `inlineClients` (case-insensitive
+ * substring) are also inlined — claude.ai does not load a Vite dev module
+ * graph from an external origin. Everyone else gets the dev-server HTML with
+ * real HMR.
+ */
+export function shouldInlineWidgetHtml(options: {
+  clientInfo: ClientIdentity | undefined;
+  inlineClients: string[];
+  forceInline?: boolean;
+}): boolean {
+  if (options.forceInline) {
+    return true;
+  }
+
+  const identityText = [options.clientInfo?.name, options.clientInfo?.title]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+  if (!identityText) {
+    return true;
+  }
+
+  return options.inlineClients.some((client) => identityText.includes(client));
+}
+
+export interface WidgetOrigin {
+  origin: string;
+  wsOrigin: string;
+  isLocalhost: boolean;
+}
+
+/**
+ * Resolve the public origin the widget dev server is reachable at.
+ *
+ * When BASE_URL is set (e.g. an `ssh -R 0 pom.run` tunnel to the widget dev
+ * server), widget HTML and CSP domains use it; otherwise localhost.
+ */
+export function resolveWidgetOrigin(
+  baseUrl: string | undefined,
+  widgetPort: number
+): WidgetOrigin {
+  const trimmed = baseUrl?.trim();
+  const url = new URL(
+    trimmed && trimmed.length > 0 ? trimmed : `http://localhost:${widgetPort}`
+  );
+  const origin = url.origin;
+  return {
+    origin,
+    wsOrigin: origin.replace(/^http/, 'ws'),
+    isLocalhost: url.hostname === 'localhost' || url.hostname === '127.0.0.1',
+  };
+}
+
+const GOOGLE_FONTS_LINK =
+  '<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap">';
+
+export const GOOGLE_FONTS_DOMAINS = [
+  'https://fonts.googleapis.com',
+  'https://fonts.gstatic.com',
+];
+
+/**
+ * Inline built JS/CSS assets into widget HTML so it renders in hosts that
+ * cannot load external resources (e.g. claude.ai). Local @fontsource fonts
+ * cannot survive inlining, so Google Fonts are injected as a replacement —
+ * remember to allow GOOGLE_FONTS_DOMAINS in the resource CSP.
+ */
+export function inlineWidgetAssets(
+  html: string,
+  assetsDir: string,
+  logger: WidgetHtmlLogger = noopLogger
+): string {
+  logger.debug({ htmlLength: html.length }, 'Inlining widget assets');
+  let nextHtml = html;
+  const scripts = Array.from(
+    html.matchAll(
+      /<script[^>]*type="module"[^>]*src="([^"]+)"[^>]*><\/script>/g
+    )
+  );
+  logger.debug(
+    { scriptMatches: scripts.length },
+    'Found script tags to inline'
+  );
+  for (const match of scripts) {
+    const src = match[1];
+    const filename = path.basename(src.split('?')[0]);
+    const assetPath = path.join(assetsDir, filename);
+    if (!fs.existsSync(assetPath)) {
+      logger.warn(
+        { assetPath },
+        'Inline asset missing, leaving script tag as-is'
+      );
+      continue;
+    }
+    const js = fs.readFileSync(assetPath);
+    const b64 = js.toString('base64');
+    const inlineTag = `<script type="module" src="data:text/javascript;base64,${b64}"></script>`;
+    nextHtml = nextHtml.replace(match[0], () => inlineTag);
+  }
+
+  const styles = Array.from(
+    html.matchAll(/<link[^>]*rel="stylesheet"[^>]*href="([^"]+)"[^>]*>/g)
+  );
+  for (const match of styles) {
+    const href = match[1];
+    const filename = path.basename(href.split('?')[0]);
+    const assetPath = path.join(assetsDir, filename);
+    if (!fs.existsSync(assetPath)) {
+      logger.warn(
+        { assetPath },
+        'Inline asset missing, leaving style tag as-is'
+      );
+      continue;
+    }
+
+    const css = fs.readFileSync(assetPath, 'utf-8');
+    const inlineTag = `<style>${css}</style>`;
+    nextHtml = nextHtml.replace(match[0], () => inlineTag);
+  }
+
+  nextHtml = nextHtml
+    .replace(/<link[^>]*rel="modulepreload"[^>]*>/g, '')
+    .replace(/<link[^>]*rel="preload"[^>]*as="style"[^>]*>/g, '')
+    .replace('</head>', `${GOOGLE_FONTS_LINK}\n</head>`);
+
+  logger.debug(
+    {
+      finalLength: nextHtml.length,
+      hasLocalhost: nextHtml.includes('localhost'),
+    },
+    'Inlining complete'
+  );
+
+  return nextHtml;
+}

--- a/server/src/widget-html.ts
+++ b/server/src/widget-html.ts
@@ -79,16 +79,28 @@ export function shouldInlineWidgetHtml(options: {
     return true;
   }
 
-  const identityText = [options.clientInfo?.name, options.clientInfo?.title]
+  if (!options.clientInfo?.name && !options.clientInfo?.title) {
+    return true;
+  }
+
+  return clientMatches(options.clientInfo, options.inlineClients);
+}
+
+/** Case-insensitive substring match of a client's name/title against a list */
+export function clientMatches(
+  clientInfo: ClientIdentity | undefined,
+  clients: string[]
+): boolean {
+  const identityText = [clientInfo?.name, clientInfo?.title]
     .filter(Boolean)
     .join(' ')
     .toLowerCase();
 
   if (!identityText) {
-    return true;
+    return false;
   }
 
-  return options.inlineClients.some((client) => identityText.includes(client));
+  return clients.some((client) => identityText.includes(client));
 }
 
 export interface WidgetOrigin {
@@ -117,6 +129,41 @@ export function resolveWidgetOrigin(
     wsOrigin: origin.replace(/^http/, 'ws'),
     isLocalhost: url.hostname === 'localhost' || url.hostname === '127.0.0.1',
   };
+}
+
+/**
+ * Minimal dev HTML that loads the Vite dev module graph via dynamic import()
+ * instead of a static <script src> tag. Hosts that render widget HTML in
+ * srcdoc iframes (e.g. claude.ai) don't execute static external script tags,
+ * but do allow dynamic loading from origins declared in resourceDomains —
+ * see the official ext-apps map-server example, which loads CesiumJS this
+ * way. Experimental: enable per client via WIDGET_BOOTSTRAP_CLIENTS.
+ */
+export function buildDevBootstrapHtml(
+  widgetId: string,
+  widgetOrigin: string
+): string {
+  const moduleUrl = `${widgetOrigin}/virtual:widget-${widgetId}.js`;
+  return `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${widgetId}</title>
+</head>
+<body>
+  <div id="${widgetId}-root"></div>
+  <script type="module">
+    import(${JSON.stringify(moduleUrl)}).catch((err) => {
+      const root = document.getElementById(${JSON.stringify(`${widgetId}-root`)});
+      if (root) {
+        root.textContent =
+          'Failed to load dev modules from ${widgetOrigin}: ' + err;
+      }
+    });
+  </script>
+</body>
+</html>`;
 }
 
 const GOOGLE_FONTS_LINK =

--- a/server/tests/widget-html.test.ts
+++ b/server/tests/widget-html.test.ts
@@ -7,6 +7,8 @@ import {
   type ServerContext,
 } from '@modelcontextprotocol/server';
 import {
+  buildDevBootstrapHtml,
+  clientMatches,
   getClientIdentity,
   inlineWidgetAssets,
   parseClientList,
@@ -105,6 +107,34 @@ describe('shouldInlineWidgetHtml', () => {
     expect(
       shouldInlineWidgetHtml({ clientInfo: { name: 'chatgpt' }, inlineClients })
     ).toBe(false);
+  });
+});
+
+describe('clientMatches', () => {
+  it('matches on name or title, case-insensitive substring', () => {
+    expect(clientMatches({ name: 'Claude-AI' }, ['claude'])).toBe(true);
+    expect(clientMatches({ title: 'claude.ai web' }, ['claude'])).toBe(true);
+    expect(clientMatches({ name: 'chatgpt' }, ['claude'])).toBe(false);
+  });
+
+  it('never matches unidentified clients or empty lists', () => {
+    expect(clientMatches(undefined, ['claude'])).toBe(false);
+    expect(clientMatches({ name: 'claude-ai' }, [])).toBe(false);
+  });
+});
+
+describe('buildDevBootstrapHtml', () => {
+  it('loads the widget module via dynamic import, not a static script src', () => {
+    const html = buildDevBootstrapHtml(
+      'echo',
+      'https://widgets.example.pom.run'
+    );
+
+    expect(html).toContain(
+      'import("https://widgets.example.pom.run/virtual:widget-echo.js")'
+    );
+    expect(html).toContain('id="echo-root"');
+    expect(html).not.toMatch(/<script[^>]*src=/);
   });
 });
 

--- a/server/tests/widget-html.test.ts
+++ b/server/tests/widget-html.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  CLIENT_INFO_META_KEY,
+  type ServerContext,
+} from '@modelcontextprotocol/server';
+import {
+  getClientIdentity,
+  inlineWidgetAssets,
+  parseClientList,
+  resolveWidgetOrigin,
+  shouldInlineWidgetHtml,
+} from '../src/widget-html.js';
+
+function contextWithClientInfo(info: unknown): ServerContext {
+  return {
+    mcpReq: {
+      envelope: info === undefined ? {} : { [CLIENT_INFO_META_KEY]: info },
+    },
+  } as unknown as ServerContext;
+}
+
+describe('getClientIdentity', () => {
+  it('extracts name, title, and version from the request envelope', () => {
+    const ctx = contextWithClientInfo({
+      name: 'claude-ai',
+      title: 'Claude',
+      version: '2.0.0',
+    });
+
+    expect(getClientIdentity(ctx)).toEqual({
+      name: 'claude-ai',
+      title: 'Claude',
+      version: '2.0.0',
+    });
+  });
+
+  it('returns undefined when the envelope has no client info', () => {
+    expect(getClientIdentity(contextWithClientInfo(undefined))).toBeUndefined();
+    expect(getClientIdentity(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for malformed client info', () => {
+    expect(getClientIdentity(contextWithClientInfo('claude'))).toBeUndefined();
+    expect(
+      getClientIdentity(contextWithClientInfo({ name: 123 }))
+    ).toBeUndefined();
+  });
+});
+
+describe('parseClientList', () => {
+  it('falls back when unset', () => {
+    expect(parseClientList(undefined, ['claude'])).toEqual(['claude']);
+  });
+
+  it('splits, trims, and lowercases entries', () => {
+    expect(parseClientList(' Claude , LibreChat ,', [])).toEqual([
+      'claude',
+      'librechat',
+    ]);
+  });
+
+  it('returns an empty list for an explicitly empty value', () => {
+    expect(parseClientList('', ['claude'])).toEqual([]);
+  });
+});
+
+describe('shouldInlineWidgetHtml', () => {
+  const inlineClients = ['claude'];
+
+  it('inlines when forced', () => {
+    expect(
+      shouldInlineWidgetHtml({
+        clientInfo: { name: 'chatgpt' },
+        inlineClients,
+        forceInline: true,
+      })
+    ).toBe(true);
+  });
+
+  it('inlines for unidentified clients', () => {
+    expect(
+      shouldInlineWidgetHtml({ clientInfo: undefined, inlineClients })
+    ).toBe(true);
+  });
+
+  it('inlines for clients matching the list (case-insensitive substring)', () => {
+    expect(
+      shouldInlineWidgetHtml({
+        clientInfo: { name: 'Claude-AI' },
+        inlineClients,
+      })
+    ).toBe(true);
+    expect(
+      shouldInlineWidgetHtml({
+        clientInfo: { title: 'claude.ai web' },
+        inlineClients,
+      })
+    ).toBe(true);
+  });
+
+  it('serves dev-server HTML to identified non-matching clients', () => {
+    expect(
+      shouldInlineWidgetHtml({ clientInfo: { name: 'chatgpt' }, inlineClients })
+    ).toBe(false);
+  });
+});
+
+describe('resolveWidgetOrigin', () => {
+  it('falls back to localhost with the widget port', () => {
+    expect(resolveWidgetOrigin(undefined, 4444)).toEqual({
+      origin: 'http://localhost:4444',
+      wsOrigin: 'ws://localhost:4444',
+      isLocalhost: true,
+    });
+  });
+
+  it('uses BASE_URL and maps https to wss', () => {
+    expect(
+      resolveWidgetOrigin('https://widgets.example.pom.run/', 4444)
+    ).toEqual({
+      origin: 'https://widgets.example.pom.run',
+      wsOrigin: 'wss://widgets.example.pom.run',
+      isLocalhost: false,
+    });
+  });
+});
+
+describe('inlineWidgetAssets', () => {
+  let assetsDir: string;
+
+  beforeAll(() => {
+    assetsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'widget-html-test-'));
+    fs.writeFileSync(path.join(assetsDir, 'echo-abc123.js'), 'console.log(1);');
+    fs.writeFileSync(path.join(assetsDir, 'echo-def456.css'), 'body{margin:0}');
+  });
+
+  afterAll(() => {
+    fs.rmSync(assetsDir, { recursive: true, force: true });
+  });
+
+  const html = [
+    '<!doctype html>',
+    '<html>',
+    '<head>',
+    '<link rel="modulepreload" href="http://localhost:4444/echo-abc123.js">',
+    '<link rel="preload" href="http://localhost:4444/echo-def456.css" as="style">',
+    '<script type="module" src="http://localhost:4444/echo-abc123.js"></script>',
+    '<link rel="stylesheet" href="http://localhost:4444/echo-def456.css">',
+    '</head>',
+    '<body><div id="echo-root"></div></body>',
+    '</html>',
+  ].join('\n');
+
+  it('inlines JS and CSS, strips preloads, and injects Google Fonts', () => {
+    const result = inlineWidgetAssets(html, assetsDir);
+
+    expect(result).toContain('data:text/javascript;base64,');
+    expect(result).toContain('<style>body{margin:0}</style>');
+    expect(result).not.toContain('modulepreload');
+    expect(result).not.toContain('rel="preload"');
+    expect(result).not.toContain('localhost');
+    expect(result).toContain('fonts.googleapis.com');
+  });
+
+  it('leaves tags referencing missing assets untouched', () => {
+    const missing = html.replaceAll('echo-abc123.js', 'gone.js');
+    const result = inlineWidgetAssets(missing, assetsDir);
+
+    expect(result).toContain('src="http://localhost:4444/gone.js"');
+  });
+});

--- a/widgets/vite-plugin-widgets.ts
+++ b/widgets/vite-plugin-widgets.ts
@@ -11,6 +11,19 @@ interface WidgetEntry {
 }
 
 /**
+ * Public base URL widget assets are served from. BASE_URL covers both a
+ * production CDN and a dev tunnel to the widget dev server (e.g. an
+ * `ssh -R 0 pom.run` tunnel to port 4444); localhost is the fallback.
+ */
+function resolvePublicBaseUrl(): string {
+  const widgetPort = process.env.WIDGET_PORT || '4444';
+  const defaultBaseUrl = `http://localhost:${widgetPort}`;
+  const candidate = process.env.BASE_URL?.trim() ?? '';
+  const baseUrl = candidate.length > 0 ? candidate : defaultBaseUrl;
+  return baseUrl.replace(/\/+$/, '') || defaultBaseUrl;
+}
+
+/**
  * Vite plugin that auto-discovers widgets and builds them separately
  * Widgets must include mounting code at the bottom of their files
  */
@@ -184,8 +197,7 @@ import ${JSON.stringify(widgetPath)};`,
 
         if (!widget) return next();
 
-        const widgetPort = process.env.WIDGET_PORT || '4444';
-        const baseUrl = `http://localhost:${widgetPort}`;
+        const baseUrl = resolvePublicBaseUrl();
 
         const html = `<!doctype html>
 <html>
@@ -237,12 +249,7 @@ import ${JSON.stringify(widgetPath)};`,
           console.log(`  ${widget.name}.css → ${widget.name}-${cssHash}.css`);
         }
 
-        const widgetPort = process.env.WIDGET_PORT || '4444';
-        const defaultBaseUrl = `http://localhost:${widgetPort}`;
-        const baseUrlCandidate = process.env.BASE_URL?.trim() ?? '';
-        const baseUrlRaw =
-          baseUrlCandidate.length > 0 ? baseUrlCandidate : defaultBaseUrl;
-        const baseUrl = baseUrlRaw.replace(/\/+$/, '') || defaultBaseUrl;
+        const baseUrl = resolvePublicBaseUrl();
 
         const html = `<!doctype html>
 <html>

--- a/widgets/vite.config.ts
+++ b/widgets/vite.config.ts
@@ -5,7 +5,7 @@ import compression from 'vite-plugin-compression';
 import { widgetDiscoveryPlugin } from './vite-plugin-widgets.ts';
 import path from 'path';
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ mode, command }) => {
   // loadEnv with '' prefix loads all .env vars (not just VITE_-prefixed ones).
   // Inject into process.env so vite-plugin-widgets can read BASE_URL at build time.
   const env = loadEnv(mode, path.resolve(import.meta.dirname, '..'), '');
@@ -14,8 +14,19 @@ export default defineConfig(({ mode }) => {
   }
 
   const isProd = process.env.NODE_ENV === 'production';
-  const inlineAssets = env.INLINE_DEV_MODE === 'true';
+  // Dev builds feed the inline HTML fallback (hosts like claude.ai that
+  // can't load external assets), so embed local images as data URIs there.
+  const inlineAssets = env.INLINE_DEV_MODE === 'true' || !isProd;
   const widgetPort = Number(process.env.WIDGET_PORT || env.WIDGET_PORT || 4444);
+
+  // When BASE_URL points at a tunnel to this dev server (e.g. ssh -R 0
+  // pom.run), accept its Host header and point the HMR websocket at it.
+  const baseUrl = (process.env.BASE_URL || env.BASE_URL || '').trim();
+  const publicUrl = baseUrl ? new URL(baseUrl) : undefined;
+  const tunneled =
+    publicUrl &&
+    publicUrl.hostname !== 'localhost' &&
+    publicUrl.hostname !== '127.0.0.1';
 
   return {
     envDir: '..', // load .env from repo root for import.meta.env in client code
@@ -50,8 +61,29 @@ export default defineConfig(({ mode }) => {
       fs: {
         allow: ['..'],
       },
+      // The background watch build (npm run dev) rewrites ../assets on every
+      // change; don't let those writes trigger full page reloads on top of HMR.
+      watch: {
+        ignored: [path.resolve(import.meta.dirname, '../assets') + '/**'],
+      },
+      ...(tunneled
+        ? {
+            allowedHosts: [publicUrl.hostname],
+            hmr: {
+              protocol: publicUrl.protocol === 'https:' ? 'wss' : 'ws',
+              host: publicUrl.hostname,
+              clientPort: publicUrl.port
+                ? Number(publicUrl.port)
+                : publicUrl.protocol === 'https:'
+                  ? 443
+                  : 80,
+            },
+          }
+        : {}),
     },
-    publicDir: '../assets',
+    // Serve built assets through the dev server, but don't copy the output
+    // directory onto itself during builds (outDir is also ../assets).
+    publicDir: command === 'serve' ? '../assets' : false,
     build: {
       target: 'es2023',
       outDir: '../assets',


### PR DESCRIPTION
## Summary

Reworks the development workflow so `npm run dev` covers every host with zero manual build steps. Dev-only — production serving is unchanged.

- **Per-client widget HTML** — the widget resource callback inspects each MCP request's `clientInfo`: clients matching `WIDGET_INLINE_CLIENTS` (default `claude`) and unidentified clients get fully inlined HTML rebuilt on every file change by a background `vite build --watch`; everyone else (e.g. ChatGPT dev mode) gets live Vite dev-server modules with HMR.
- **`BASE_URL` doubles as the widget dev tunnel** — widget asset URLs, CSP resource/connect domains (including the `wss://` HMR websocket), and Vite `allowedHosts`/HMR config all derive from it, so a second `ssh -R` tunnel to port 4444 gives HMR through hosts that load external assets.
- **Experimental `WIDGET_BOOTSTRAP_CLIENTS`** (off by default) — serves a minimal HTML that loads the dev module graph via dynamic `import()`, probing whether srcdoc-iframe hosts like claude.ai allow dynamic loading from CSP `resourceDomains` (the pattern the official ext-apps map-server example uses). If it proves out, it enables no-build dev there too.
- **Edit-loop fixes** — watch-build writes to `assets/` no longer trigger full page reloads on HMR clients, and the `publicDir`/`outDir` warning is silenced by scoping `publicDir` to serve only.
- Centralizes the ext-apps v1-SDK bridge cast into a single `extAppsServer` alias (drop when ext-apps ships v2 SDK types).
- Docs: README/AGENTS.md explain the two delivery pipelines (first render, edit loop, production).

## Testing

- `server/tests/widget-html.test.ts` covers the new client-matching and HTML-building helpers
- Verified against claude.ai (inlined path) and ChatGPT dev mode (HMR path); bootstrap flag verified against the compiled server with both client lists set

## Risks / follow-ups

- The bootstrap flag is experimental and requires an https `BASE_URL` tunnel; it needs validation against claude.ai before promoting it beyond an opt-in env var
- All new behavior is gated on `NODE_ENV=development`; production hosts continue to fetch built assets from `BASE_URL`/`assets/`

## AI Disclosure

This branch was developed with Claude Code, with me directing the design, testing the flows against real hosts (claude.ai and ChatGPT dev mode), pushing back where its first approach didn't hold up, and reviewing everything before it landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)