### PR TITLE
fix(dev): bind Vite on IPv4 when reverse-tunneling

### DIFF
--- a/widgets/vite-plugin-widgets.ts
+++ b/widgets/vite-plugin-widgets.ts
@@ -189,20 +189,6 @@ import ${JSON.stringify(widgetPath)};`,
 
         const url = req.url.split('?')[0];
 
-        // Health checks and people opening the tunnel origin hit `/`.
-        // There is no root app; 404 here makes the UI route look down.
-        if (url === '/' || url === '/health') {
-          const names = widgets.map((widget) => widget.name);
-          res.statusCode = 200;
-          res.setHeader('Content-Type', 'text/plain; charset=utf-8');
-          res.end(
-            url === '/health'
-              ? 'ok\n'
-              : `widgets\n${names.map((name) => `/${name}.html`).join('\n')}\n`
-          );
-          return;
-        }
-
         const htmlMatch = url.match(/^\/([\w-]+)(?:\.html)?$/);
         if (!htmlMatch) return next();
 

--- a/widgets/vite-plugin-widgets.ts
+++ b/widgets/vite-plugin-widgets.ts
@@ -189,6 +189,20 @@ import ${JSON.stringify(widgetPath)};`,
 
         const url = req.url.split('?')[0];
 
+        // Health checks and people opening the tunnel origin hit `/`.
+        // There is no root app; 404 here makes the UI route look down.
+        if (url === '/' || url === '/health') {
+          const names = widgets.map((widget) => widget.name);
+          res.statusCode = 200;
+          res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+          res.end(
+            url === '/health'
+              ? 'ok\n'
+              : `widgets\n${names.map((name) => `/${name}.html`).join('\n')}\n`
+          );
+          return;
+        }
+
         const htmlMatch = url.match(/^\/([\w-]+)(?:\.html)?$/);
         if (!htmlMatch) return next();
 

--- a/widgets/vite.config.ts
+++ b/widgets/vite.config.ts
@@ -68,6 +68,9 @@ export default defineConfig(({ mode, command }) => {
       },
       ...(tunneled
         ? {
+            // Default `localhost` binds [::1] only. Pomerium's reverse tunnel
+            // connects to 127.0.0.1:4444 and 503s without an IPv4 listener.
+            host: true,
             allowedHosts: [publicUrl.hostname],
             hmr: {
               protocol: publicUrl.protocol === 'https:' ? 'wss' : 'ws',

--- a/widgets/vite.config.ts
+++ b/widgets/vite.config.ts
@@ -68,8 +68,8 @@ export default defineConfig(({ mode, command }) => {
       },
       ...(tunneled
         ? {
-            // Default `localhost` binds [::1] only. Pomerium's reverse tunnel
-            // connects to 127.0.0.1:4444 and 503s without an IPv4 listener.
+            // Default `localhost` binds [::1] only. Reverse tunnels typically
+            // connect to 127.0.0.1:4444 and 503 if there is no IPv4 listener.
             host: true,
             allowedHosts: [publicUrl.hostname],
             hmr: {

--- a/widgets/vite.config.ts
+++ b/widgets/vite.config.ts
@@ -68,8 +68,8 @@ export default defineConfig(({ mode, command }) => {
       },
       ...(tunneled
         ? {
-            // Default `localhost` binds [::1] only. Reverse tunnels typically
-            // connect to 127.0.0.1:4444 and 503 if there is no IPv4 listener.
+            // Default `localhost` can bind [::1] only. Listen on all
+            // addresses so 127.0.0.1 works too.
             host: true,
             allowedHosts: [publicUrl.hostname],
             hmr: {


### PR DESCRIPTION
## Summary
- Dev-only Vite listen: when `BASE_URL` is a non-localhost origin, bind on all addresses (`host: true`) so Pomerium `ssh -R` or any tunneling service can reach `127.0.0.1:4444` instead of 503 `connection_timeout`.

Closes #116

## Test plan
- [x] `npm run dev` with no `BASE_URL` still serves widgets on `localhost:4444`
- [x] `BASE_URL` set: widget HTML returns 200 on `localhost` and `127.0.0.1` (including `Host` of the UI tunnel)